### PR TITLE
Fix reproducible build issues with Git hashes and apkdiff.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -515,7 +515,7 @@ def getLastCommitTimestamp() {
 def getGitHash() {
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        commandLine 'git', 'rev-parse', 'HEAD'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/reproducible-builds/apkdiff/apkdiff.py
+++ b/reproducible-builds/apkdiff/apkdiff.py
@@ -4,9 +4,7 @@ import sys
 from zipfile import ZipFile
 
 class ApkDiff:
-    # resources.arsc is ignored due to https://issuetracker.google.com/issues/110237303
-    # May be fixed in Android Gradle Plugin 3.4
-    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "resources.arsc"]
+    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "META-INF/CERTIFIC.RSA", "META-INF/CERTIFIC.SF"]
 
     def compare(self, sourceApk, destinationApk):
         sourceZip      = ZipFile(sourceApk, 'r')


### PR DESCRIPTION
We stop using abbreviated Git hashes and use full hashes instead for the 
debug log output. According to
https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892,
the default abbreviation is subject to auto sizing depending on the
estimated number of objects in the Git repository. This number can
differ if the Signal developers use private branches for developing but
then only push the squashed commits to the public repository.

To solve this, we just use the full Git hash. The GIT_HASH config field
is only used in the debug log print out anyway, and using the full hash
instead of a hardcoded abbreviated size helps future-proof it as well.

For apkdiff, we ignore the new file names signing info. We keep the
older versions in case they change again (or if someone wants to verify
a previous version of Signal that had the old names).  Also, the
resources.arsc issue seems to be resolved according to the Google Issue
and local testing.

Fixes #10476

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have read [how to contribute](https://github.com/signalapp/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/signalapp/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
