### PR TITLE
Fix reproducible build issues with Git hashes and apkdiff. (#2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -515,7 +515,7 @@ def getLastCommitTimestamp() {
 def getGitHash() {
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        commandLine 'git', 'rev-parse', 'HEAD'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/reproducible-builds/apkdiff/apkdiff.py
+++ b/reproducible-builds/apkdiff/apkdiff.py
@@ -4,9 +4,7 @@ import sys
 from zipfile import ZipFile
 
 class ApkDiff:
-    # resources.arsc is ignored due to https://issuetracker.google.com/issues/110237303
-    # May be fixed in Android Gradle Plugin 3.4
-    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "resources.arsc"]
+    IGNORE_FILES = ["META-INF/MANIFEST.MF", "META-INF/SIGNAL_S.RSA", "META-INF/SIGNAL_S.SF", "META-INF/CERTIFIC.RSA", "META-INF/CERTIFIC.SF"]
 
     def compare(self, sourceApk, destinationApk):
         sourceZip      = ZipFile(sourceApk, 'r')


### PR DESCRIPTION
Why does GitHub not have a dedicated rebase interface?